### PR TITLE
Stop trying to add polymorphic associated factories to the list

### DIFF
--- a/lib/factory_burgers/introspection.rb
+++ b/lib/factory_burgers/introspection.rb
@@ -11,13 +11,15 @@ module FactoryBurgers
     # Return a list of factories for a model instance's associations
     def association_factories(klass)
       buildable_associations(klass).flat_map do |assoc|
+        next if assoc.options[:polymorphic]
+ 
         factories_for_class(assoc.klass).map do |factory|
           {
             association: assoc,
             factory: factory,
           }
         end
-      end
+      end.compact
     end
 
     def factories_for_class(klass)


### PR DESCRIPTION
After a model with polymorphic associations has been created, a list of associated factories cannot be compiled if any of the associations are polymorphic. We skip these associations as they are incalculable.

![image](https://github.com/NEXL-LTS/factory_burgers/assets/213006/dc41267e-5e2a-46ff-ab64-23d9e914cc0b)
